### PR TITLE
🔥 Revert to default behaviour of Nexmo

### DIFF
--- a/lib/textris/delivery/nexmo.rb
+++ b/lib/textris/delivery/nexmo.rb
@@ -11,7 +11,7 @@ module Textris
 
       private
         def client
-          @client ||= ::Nexmo::Client.new(api_key: Rails.application.credentials.nexmo[:api_key], api_secret: Rails.application.credentials.nexmo[:api_secret])
+          @client ||= ::Nexmo::Client.new
         end
 
         def sender_id


### PR DESCRIPTION
Code was added to use Rails Credentials for Nexmo, but from a library point of view, this should not come from Rails.

Nexmo uses env vars by default. Env vars should be set from the Rails Credentials instead, and then Nexmo will be initialized using these env vars.

This is needed for keeping compatibility with other users of the library (for instance Amaretti).