### PR TITLE
🐛 Fix log level configuration

### DIFF
--- a/lib/textris/delivery/log.rb
+++ b/lib/textris/delivery/log.rb
@@ -3,10 +3,10 @@ module Textris
     class Log < Textris::Delivery::Base
       def deliver(to)
         log :debug, "Sent text to #{Phony.format(to)}"
-        log :debug, "Texter: #{message.texter || 'UnknownTexter'}" + "#" +
+        log :info, "Texter: #{message.texter || 'UnknownTexter'}" + "#" +
           "#{message.action || 'unknown_action'}"
-        log :debug, "Date: #{Time.now}"
-        log :debug, "From: #{message.from || message.twilio_messaging_service_sid || 'unknown'}"
+        log :info, "Date: #{Time.now}"
+        log :info, "From: #{message.from || message.twilio_messaging_service_sid || 'unknown'}"
         log :debug, "To: #{message.to.map { |i| Phony.format(to) }.join(', ')}"
         log :debug, "Content: #{message.content}"
         (message.media_urls || []).each_with_index do |media_url, index|

--- a/lib/textris/delivery/log.rb
+++ b/lib/textris/delivery/log.rb
@@ -1,8 +1,6 @@
 module Textris
   module Delivery
     class Log < Textris::Delivery::Base
-      AVAILABLE_LOG_LEVELS = %w{debug info warn error fatal unknown}
-
       def deliver(to)
         log :info,  "Sent text to #{Phony.format(to)}"
         log :debug, "Texter: #{message.texter || 'UnknownTexter'}" + "#" +
@@ -21,12 +19,6 @@ module Textris
       private
 
       def log(level, message)
-        level = Rails.application.config.try(:textris_log_level) || level
-
-        unless AVAILABLE_LOG_LEVELS.include?(level.to_s)
-          raise(ArgumentError, "Wrong log level: #{level}")
-        end
-
         Rails.logger.send(level, message)
       end
     end

--- a/lib/textris/delivery/log.rb
+++ b/lib/textris/delivery/log.rb
@@ -2,7 +2,7 @@ module Textris
   module Delivery
     class Log < Textris::Delivery::Base
       def deliver(to)
-        log :info,  "Sent text to #{Phony.format(to)}"
+        log :debug, "Sent text to #{Phony.format(to)}"
         log :debug, "Texter: #{message.texter || 'UnknownTexter'}" + "#" +
           "#{message.action || 'unknown_action'}"
         log :debug, "Date: #{Time.now}"

--- a/lib/textris/delivery/log.rb
+++ b/lib/textris/delivery/log.rb
@@ -2,24 +2,30 @@ module Textris
   module Delivery
     class Log < Textris::Delivery::Base
       def deliver(to)
-        log :debug, "Sent text to #{Phony.format(to)}"
-        log :info, "Texter: #{message.texter || 'UnknownTexter'}" + "#" +
-          "#{message.action || 'unknown_action'}"
-        log :info, "Date: #{Time.now}"
-        log :info, "From: #{message.from || message.twilio_messaging_service_sid || 'unknown'}"
-        log :debug, "To: #{message.to.map { |i| Phony.format(to) }.join(', ')}"
-        log :debug, "Content: #{message.content}"
+        Rails.logger.debug("Textris") { "Sent text to #{Phony.format(to)}" }
+        Rails
+          .logger
+          .info("Textris") do
+            "Texter: #{message.texter || "UnknownTexter"}" + "#" +
+              "#{message.action || "unknown_action"}"
+          end
+        Rails.logger.info("Textris") { "Date: #{Time.now}" }
+        Rails
+          .logger
+          .info("Textris") do
+            "From: #{message.from || message.twilio_messaging_service_sid || "unknown"}"
+          end
+        Rails
+          .logger
+          .debug("Textris") do
+            "To: #{message.to.map { |i| Phony.format(to) }.join(", ")}"
+          end
+        Rails.logger.debug("Textris") { "Content: #{message.content}" }
         (message.media_urls || []).each_with_index do |media_url, index|
           logged_message = index == 0 ? "Media URLs: " : "            "
           logged_message << media_url
-          log :debug, logged_message
+          Rails.logger.debug("Textris") { logged_message }
         end
-      end
-
-      private
-
-      def log(level, message)
-        Rails.logger.send(level, message)
       end
     end
   end


### PR DESCRIPTION
## 🐛 Fix log level configuration

The log level configuration of Textris was actually bypassing all log levels set in the code, leading to logging everything in production.

This commit fixes the issue by keeping the default behaviour of Rails.logger.

## 🛠️ Change log level of "Send text to"

This log level was set to info, but production env is set up to log this level, which lead to leaking phone numbers to observability platforms.

This commit fixes the issue by downgrading this log level.

## 🛠️ Set some non-identifying data to log level info

## ♻️ Use block style logging